### PR TITLE
Fix: Input Validation Length

### DIFF
--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -24,9 +24,9 @@ export const usersRoute = new Elysia({ prefix: "/api/users" })
     },
     {
       body: t.Object({
-        name: t.String(),
-        email: t.String(),
-        password: t.String(),
+        name: t.String({ maxLength: 255 }),
+        email: t.String({ maxLength: 255 }),
+        password: t.String({ maxLength: 255 }),
       }),
     },
   )
@@ -47,8 +47,8 @@ export const usersRoute = new Elysia({ prefix: "/api/users" })
     },
     {
       body: t.Object({
-        email: t.String(),
-        password: t.String(),
+        email: t.String({ maxLength: 255 }),
+        password: t.String({ maxLength: 255 }),
       }),
     },
   )


### PR DESCRIPTION
This PR fixes issue #12 by adding TypeBox schema validation for input length. - Hits: POST /api/users, POST /api/users/login - Fixes: 500 error when submitting strings longer than 255 chars - Result: Returns 422 Unprocessable Entity with descriptive error